### PR TITLE
Split arguments for the script out to CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,5 @@ COPY letsencrypt-aws.py ./
 
 USER nobody
 
-ENTRYPOINT [".venv/bin/python", "letsencrypt-aws.py", "update-certificates"]
+ENTRYPOINT [".venv/bin/python", "letsencrypt-aws.py"]
+CMD ["update-certificates"]


### PR DESCRIPTION
This allows you to invoke the script to register, as well as updating certificates.

`docker run letsencrypt-aws register <email>`
=> runs `.venv/bin/python letsencrypt-aws.py register <email>`

`docker run letsencrypt-aws`
`docker run letsencrypt-aws update-certificates`
=> both run `.venv/bin/python letsencrypt-aws.py update-certificates`

Before this fix, you would have to override the entrypoint to use it to register:

`docker run --entrypoint=".venv/bin/python" letsencrypt-aws letsencrypt-aws.py register <email>`

More information on the best practices regarding `ENTRYPOINT` and `CMD`: https://docs.docker.com/engine/articles/dockerfile_best-practices/#entrypoint
