### PR TITLE
added --cross-profile to be able to handle Route53 and ELBs in different accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ An example IAM policy is:
 ### Cross-Account handling
 You will need this feature, if Route53 is managed through your main account and ELB are provisioned in a separate AWS account.
 
-[AWS Examples of Policies for Delegating Access](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_policy-examples.html)
+Useful documentations: [AWS Examples of Policies for Delegating Access](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_policy-examples.html) and
 [AWS Tutorial: Delegate Access Across AWS Accounts Using IAM Roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html)
 
 In your account, which includes the ELB, you should  create a new policy:
@@ -207,7 +207,7 @@ In your account, which includes the ELB, you should  create a new policy:
 ```
 After this, you need to create a new `Role for Cross-Account Access`.
 Enter your Account ID from your main account and choose the policy you've just created.
-Edit the `Trust Relationships` and replace `"AWS": "arn:aws:iam::yourmainaccountnumber:root"` with
+Edit the `Trust Relationships` and replace `arn:aws:iam::yourmainaccountnumber:root` with
 `arn:aws:iam::yourmainaccountnumber:user/youruser`
 
 In your main account, add a new policy to your user:

--- a/letsencrypt-aws.py
+++ b/letsencrypt-aws.py
@@ -309,7 +309,7 @@ def complete_dns_challenge(logger, acme_client, dns_challenge_completer,
         elb_name=elb_name, host=authz_record.host
     )
     dns_challenge_completer.wait_for_change(
-        authz_record.change_id, 
+        authz_record.change_id,
         authz_record.host
     )
 

--- a/letsencrypt-aws.py
+++ b/letsencrypt-aws.py
@@ -129,7 +129,6 @@ class Route53ChallengeCompleter(object):
         if not self.route53_cross_client:
             return self.route53_client
 
-        zones = []
         for client in (self.route53_client, self.route53_cross_client):
             paginator = client.get_paginator("list_hosted_zones")
             for page in paginator.paginate():
@@ -138,7 +137,7 @@ class Route53ChallengeCompleter(object):
                         domain.endswith(zone["Name"]) or
                         (domain + ".").endswith(zone["Name"])
                        ) and not zone["Config"]["PrivateZone"]:
-                           return client
+                            return client
 
         raise ValueError(
             "Unable to find a Route53 hosted zone for {}".format(domain)
@@ -156,7 +155,7 @@ class Route53ChallengeCompleter(object):
                         domain.endswith(zone["Name"]) or
                         (domain + ".").endswith(zone["Name"])
                        ) and not zone["Config"]["PrivateZone"]:
-                           zones.append((zone["Name"], zone["Id"]))
+                            zones.append((zone["Name"], zone["Id"]))
 
         if not zones:
             raise ValueError(
@@ -309,7 +308,10 @@ def complete_dns_challenge(logger, acme_client, dns_challenge_completer,
         "updating-elb.wait-for-route53",
         elb_name=elb_name, host=authz_record.host
     )
-    dns_challenge_completer.wait_for_change(authz_record.change_id,authz_record.host)
+    dns_challenge_completer.wait_for_change(
+        authz_record.change_id, 
+        authz_record.host
+    )
 
     response = authz_record.dns_challenge.response(acme_client.key)
 
@@ -494,9 +496,13 @@ def cli():
     )
 )
 @click.option(
-    "--cross-profile", help="Specify your profile for ELB and IAM modifications."
+    "--cross-profile", help=(
+        "Specify your profile, if Route53 and ELB are in "
+        "different accounts located."
+    )
 )
-def update_certificates(persistent=False, force_issue=False, cross_profile=False):
+def update_certificates(persistent=False, force_issue=False,
+                        cross_profile=False):
     logger = Logger()
     logger.emit("startup")
 

--- a/letsencrypt-aws.py
+++ b/letsencrypt-aws.py
@@ -467,7 +467,10 @@ def cli():
         "expiration."
     )
 )
-def update_certificates(persistent=False, force_issue=False):
+@click.option(
+    "--cross-profile", help="Specify your profile for ELB and IAM modifications."
+)
+def update_certificates(persistent=False, force_issue=False, cross_profile=False):
     logger = Logger()
     logger.emit("startup")
 
@@ -476,9 +479,14 @@ def update_certificates(persistent=False, force_issue=False):
 
     session = boto3.Session()
     s3_client = session.client("s3")
-    elb_client = session.client("elb")
     route53_client = session.client("route53")
-    iam_client = session.client("iam")
+    if cross_profile:
+        cross_session = boto3.Session(profile_name=cross_profile)
+        elb_client = cross_session.client("elb")
+        iam_client = cross_session.client("iam")
+    else:
+        elb_client = session.client("elb")
+        iam_client = session.client("iam")
 
     config = json.loads(os.environ["LETSENCRYPT_AWS_CONFIG"])
     domains = config["domains"]


### PR DESCRIPTION
For the use case, that your Route53 and ELB are in different accounts, this is a potential patch.
Included also short documentation in the README of how to use it.

Simple feature enhancement, doesn't break stuff.
Let me know if you have comments.
