### PR TITLE
handles the case where Route53 zones are in different accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ An example IAM policy is:
 ### Cross-Account handling
 You will need this feature, if Route53 is managed through your main account and ELB are provisioned in a separate AWS account.
 
-[AWS Examples of Policies for Delegating Access](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_policy-examples.html)
+Useful documentations: [AWS Examples of Policies for Delegating Access](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_policy-examples.html) and
 [AWS Tutorial: Delegate Access Across AWS Accounts Using IAM Roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html)
 
 In your account, which includes the ELB, you should  create a new policy:
@@ -207,7 +207,7 @@ In your account, which includes the ELB, you should  create a new policy:
 ```
 After this, you need to create a new `Role for Cross-Account Access`.
 Enter your Account ID from your main account and choose the policy you've just created.
-Edit the `Trust Relationships` and replace `"AWS": "arn:aws:iam::yourmainaccountnumber:root"` with
+Edit the `Trust Relationships` and replace `arn:aws:iam::yourmainaccountnumber:root` with
 `arn:aws:iam::yourmainaccountnumber:user/youruser`
 
 In your main account, add a new policy to your user:

--- a/letsencrypt-aws.py
+++ b/letsencrypt-aws.py
@@ -467,7 +467,10 @@ def cli():
         "expiration."
     )
 )
-def update_certificates(persistent=False, force_issue=False):
+@click.option(
+    "--cross-profile", help="Specify your profile for ELB and IAM modifications."
+)
+def update_certificates(persistent=False, force_issue=False, cross_profile=False):
     logger = Logger()
     logger.emit("startup")
 
@@ -476,9 +479,14 @@ def update_certificates(persistent=False, force_issue=False):
 
     session = boto3.Session()
     s3_client = session.client("s3")
-    elb_client = session.client("elb")
     route53_client = session.client("route53")
-    iam_client = session.client("iam")
+    if cross_profile:
+        cross_session = boto3.Session(profile_name=cross_profile)
+        elb_client = cross_session.client("elb")
+        iam_client = cross_session.client("iam")
+    else:
+        elb_client = session.client("elb")
+        iam_client = session.client("iam")
 
     config = json.loads(os.environ["LETSENCRYPT_AWS_CONFIG"])
     domains = config["domains"]


### PR DESCRIPTION
Feature enhancement to determine where a Route53 zone is located if `--cross-profile` is specified.
So the code can handle: Route53 and ELB in different accounts, and Route53 zones are located over two accounts as well.
Tested already in a production env without issues.

Please let me know what you think.
