### PR TITLE
Add Cloudfront and ElasticBeanstalk support

### DIFF
--- a/letsencrypt-aws.py
+++ b/letsencrypt-aws.py
@@ -558,7 +558,7 @@ def cli():
         "a listener."
     )
 )
-def update_certificates(persistent=False, force_issue=False):
+def update_certificates(persistent=False, force_issue=False, cert_only=False):
     logger = Logger()
     logger.emit("startup")
 
@@ -626,8 +626,8 @@ def update_certificates(persistent=False, force_issue=False):
     else:
         logger.emit("running", mode="single")
         update_certs(
-            logger, acme_client,
-            force_issue, certificate_requests
+            logger, acme_client, force_issue, cert_only,
+            certificate_requests
         )
 
 


### PR DESCRIPTION
Refactor Certificates into AWSCertificate sub-classes,
 allowing for the easy adding of new listener providers
 in the future. CloudFront and ElasticBeanstalk are both
 implemented this way. Fix #41

Also, add the --cert-only flag, fix #13

This PR supersedes #44 and partially #17
