### PR TITLE
Finished CloudFront support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ environment variable. This should be a JSON object with the following schema:
             },
             "hosts": ["list of hosts you want on the certificate (strings)"],
             "key_type": "rsa or ecdsa, optional, defaults to rsa (string)"
+        },
+        {
+            "cloudfront": {
+                "id": "CloudFront distribution ID (string)"
+            },
+            "hosts": ["list of hosts you want on the certificate (strings)"],
+            "key_type": "rsa or ecdsa, optional, defaults to rsa (string)"
         }
     ],
     "acme_account_key": "location of the account private key (string)",

--- a/letsencrypt-aws.py
+++ b/letsencrypt-aws.py
@@ -70,7 +70,7 @@ def _get_iam_certificate(iam_client, certificate_id):
 
 
 def _upload_iam_certificate(iam_client, hosts, private_key, pem_certificate,
-                            pem_certificate_chain):
+                            pem_certificate_chain, path="/"):
     response = iam_client.upload_server_certificate(
         ServerCertificateName=generate_certificate_name(
             hosts,
@@ -85,6 +85,7 @@ def _upload_iam_certificate(iam_client, hosts, private_key, pem_certificate,
         ),
         CertificateBody=pem_certificate,
         CertificateChain=pem_certificate_chain,
+        Path=path,
     )
     return response["ServerCertificateMetadata"]
 
@@ -158,7 +159,8 @@ class CloudFrontCertificate(object):
         logger.emit("upload-iam-certificate")
         new_cert_id = _upload_iam_certificate(
             self.iam_client,
-            hosts, private_key, pem_certificate, pem_certificate_chain
+            hosts, private_key, pem_certificate, pem_certificate_chain,
+            path="/cloudfront/"
         )["ServerCertificateId"]
 
         # Sleep before trying to set the certificate, it appears to sometimes

--- a/letsencrypt-aws.py
+++ b/letsencrypt-aws.py
@@ -54,11 +54,15 @@ class CertificateRequest(object):
         self.key_type = key_type
 
 
-def _get_iam_certificate(iam_client, certificate_id):
+def _get_iam_certificate(iam_client, id_or_arn):
     paginator = iam_client.get_paginator("list_server_certificates")
     for page in paginator.paginate():
         for server_certificate in page["ServerCertificateMetadataList"]:
-            if server_certificate["Arn"] == certificate_id:
+            if (
+                server_certificate["Arn"] == id_or_arn or
+                server_certificate["ServerCertificateId"] == id_or_arn
+            ):
+
                 cert_name = server_certificate["ServerCertificateName"]
                 response = iam_client.get_server_certificate(
                     ServerCertificateName=cert_name,

--- a/letsencrypt-aws.py
+++ b/letsencrypt-aws.py
@@ -146,10 +146,12 @@ class CloudFrontCertificate(object):
         cert = response["DistributionConfig"]["ViewerCertificate"]
         # If the cert is of a different type then we don't have code to check
         # for it, annoying.
-        assert cert.get("IAMCertificateId")
-        return _get_iam_certificate(
-            self.iam_client, cert["IAMCertificateId"]
-        )
+        if not cert.get("IAMCertificateId"):
+            return None
+        else:
+            return _get_iam_certificate(
+                self.iam_client, cert["IAMCertificateId"]
+            )
 
     def update_certificate(self, logger, hosts, private_key, pem_certificate,
                            pem_certificate_chain):
@@ -385,34 +387,38 @@ def update_elb(logger, acme_client, force_issue, cert_request):
     logger.emit("updating-elb", source=cert_request.cert_location.name)
 
     current_cert = cert_request.cert_location.get_current_certificate()
-    logger.emit(
-        "updating-elb.certificate-expiration",
-        source=cert_request.cert_location.name,
-        expiration_date=current_cert.not_valid_after
-    )
-    days_until_expiration = (
-        current_cert.not_valid_after - datetime.datetime.today()
-    )
 
-    try:
-        san_extension = current_cert.extensions.get_extension_for_class(
-            x509.SubjectAlternativeName
+    if current_cert:
+        logger.emit(
+            "updating-elb.certificate-expiration",
+            source=cert_request.cert_location.name,
+            expiration_date=current_cert.not_valid_after
         )
-    except x509.ExtensionNotFound:
-        # Handle the case where an old certificate doesn't have a SAN extension
-        # and always reissue in that case.
-        current_domains = []
-    else:
-        current_domains = san_extension.value.get_values_for_type(x509.DNSName)
+        days_until_expiration = (
+            current_cert.not_valid_after - datetime.datetime.today()
+        )
 
-    if (
-        days_until_expiration > CERTIFICATE_EXPIRATION_THRESHOLD and
-        # If the set of hosts we want for our certificate changes, we update
-        # even if the current certificate isn't expired.
-        sorted(current_domains) == sorted(cert_request.hosts) and
-        not force_issue
-    ):
-        return
+        try:
+            san_extension = current_cert.extensions.get_extension_for_class(
+                x509.SubjectAlternativeName
+            )
+        except x509.ExtensionNotFound:
+            # Handle the case where an old certificate doesn't have a SAN
+            # extension and always reissue in that case.
+            current_domains = []
+        else:
+            current_domains = san_extension.value.get_values_for_type(
+                x509.DNSName
+            )
+
+        if (
+            not force_issue and
+            days_until_expiration > CERTIFICATE_EXPIRATION_THRESHOLD and
+            # If the set of hosts we want for our certificate changes,
+            # we update even if the current certificate isn't expired.
+            sorted(current_domains) == sorted(cert_request.hosts)
+        ):
+            return
 
     if cert_request.key_type == "rsa":
         private_key = generate_rsa_private_key()

--- a/letsencrypt-aws.py
+++ b/letsencrypt-aws.py
@@ -55,12 +55,12 @@ class CertificateRequest(object):
 
 
 def _get_iam_certificate(iam_client, certificate_id):
-    paginator = self.iam_client.get_paginator("list_server_certificates")
+    paginator = iam_client.get_paginator("list_server_certificates")
     for page in paginator.paginate():
         for server_certificate in page["ServerCertificateMetadataList"]:
             if server_certificate["Arn"] == certificate_id:
                 cert_name = server_certificate["ServerCertificateName"]
-                response = self.iam_client.get_server_certificate(
+                response = iam_client.get_server_certificate(
                     ServerCertificateName=cert_name,
                 )
                 return x509.load_pem_x509_certificate(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-# Branch for https://github.com/letsencrypt/letsencrypt/pull/2061
--e git+https://github.com/wteiken/letsencrypt@add_dns01_challenge#subdirectory=acme&egg=acme[dns]
+-e git+https://github.com/certbot/certbot#subdirectory=acme&egg=acme[dns]
 boto3>=1.2.3
 click>=6.2
 cryptography>=1.1.2


### PR DESCRIPTION
These are my fixes for your PR #44 that fixes #41. Using this I was able to create, upload and configure certificate for my CloudFront distribution that didn't even use any SSL cert before. After that I've verified that on a second run the existing cert is checked for its settings and expiration time.

I didn't realize I was working in parallel with @kageurufu who submitted #56. I like his `--cert-only` option, but we took different approaches. I've based my PR on your topic branch and put my changes in multiple separate commits hoping it will make them easier to review.
