### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ it (either on the local filesystem or in S3).
 
 You will also need to have your AWS credentials configured. You can use any of
 the [mechanisms documented by
-boto3](https://boto3.readthedocs.org/en/latest/guide/configuration.html), or
+boto3](https://boto3.readthedocs.io/en/latest/guide/configuration.html), or
 use IAM instance profiles (which are supported, but not mentioned by the
 `boto3` documentation). See below for which AWS permissions are required.
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
