### PR TITLE
enable configuration via file (preferring environment)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ use IAM instance profiles (which are supported, but not mentioned by the
 `boto3` documentation). See below for which AWS permissions are required.
 
 `letsencrypt-aws` takes it's configuration via the `LETSENCRYPT_AWS_CONFIG`
-environment variable. This should be a JSON object with the following schema:
+environment variable directly or via a file pointed to by the environment
+variable `LETSENCRYPT_AWS_CONFIG_FILE`. This should be a JSON object with the
+following schema:
 
 ```json
 {

--- a/letsencrypt-aws.py
+++ b/letsencrypt-aws.py
@@ -1,4 +1,5 @@
 import datetime
+import errno
 import json
 import os
 import sys
@@ -24,6 +25,8 @@ import rfc3986
 
 DEFAULT_ACME_DIRECTORY_URL = "https://acme-v01.api.letsencrypt.org/directory"
 CERTIFICATE_EXPIRATION_THRESHOLD = datetime.timedelta(days=45)
+LETSENCRYPT_AWS_CONFIG_FILE = \
+    os.environ.get('LETSENCRYPT_AWS_CONFIG_FILE', 'config.json')
 # One day
 PERSISTENT_SLEEP_INTERVAL = 60 * 60 * 24
 DNS_TTL = 30
@@ -43,6 +46,51 @@ class Logger(object):
             formatted_data
         ))
         self._out.flush()
+
+
+class Config(object):
+    def __contains__(self, name):
+        return name in self._config
+
+    def __init__(self, logger, default=None):
+        self._config = None
+        if default is not None:
+            self._config = default
+        self.logger = logger
+        self.read()
+
+    def __getattr__(self, name):
+        return getattr(self._config, name)
+
+    def __getitem__(self, name):
+        return self._config[name]
+
+    def read(self):
+        # environment variables wont change from under us, dont bother
+        # "re-reading" it if we read it once
+        if self._config is None and 'LETSENCRYPT_AWS_CONFIG' in os.environ:
+            self._config = json.loads(os.environ['LETSENCRYPT_AWS_CONFIG'])
+            self.logger.emit("config.read-env")
+            return
+
+        # read the config file everytime
+        try:
+            with open(LETSENCRYPT_AWS_CONFIG_FILE) as fp:
+                self._config = json.loads(fp.read())
+                self.logger.emit(
+                    "config.read-file",
+                    config=LETSENCRYPT_AWS_CONFIG_FILE,
+                    mtime=os.fstat(fp.fileno()).st_mtime
+                )
+                return
+        except IOError as exc:
+            if exc.errno != errno.ENOENT:
+                raise
+
+            self.logger.emit("config.read-none")
+
+        if self._config is None:
+            raise Exception('error: no configuration specified')
 
 
 def _get_iam_certificate(iam_client, certificate_id):
@@ -495,51 +543,50 @@ def update_certificates(persistent=False, force_issue=False):
     route53_client = session.client("route53")
     iam_client = session.client("iam")
 
-    config = json.loads(os.environ["LETSENCRYPT_AWS_CONFIG"])
-    domains = config["domains"]
-    acme_directory_url = config.get(
-        "acme_directory_url", DEFAULT_ACME_DIRECTORY_URL
-    )
-    acme_account_key = config["acme_account_key"]
-    acme_client = setup_acme_client(
-        s3_client, acme_directory_url, acme_account_key
-    )
+    config = Config(logger)
+    while True:
+        logger.emit("running", mode="persistent" if persistent else "single")
 
-    certificate_requests = []
-    for domain in domains:
-        if "elb" in domain:
-            cert_location = ELBCertificate(
-                elb_client, iam_client,
-                domain["elb"]["name"], int(domain["elb"].get("port", 443))
-            )
-        else:
-            raise ValueError(
-                "Unknown certificate location: {!r}".format(domain)
-            )
+        domains = config["domains"]
+        acme_directory_url = config.get(
+            "acme_directory_url", DEFAULT_ACME_DIRECTORY_URL
+        )
+        acme_account_key = config["acme_account_key"]
+        acme_client = setup_acme_client(
+            s3_client, acme_directory_url, acme_account_key
+        )
 
-        certificate_requests.append(CertificateRequest(
-            cert_location,
-            Route53ChallengeCompleter(route53_client),
-            domain["hosts"],
-            domain.get("key_type", "rsa"),
-        ))
+        certificate_requests = []
+        for domain in domains:
+            if "elb" in domain:
+                cert_location = ELBCertificate(
+                    elb_client, iam_client,
+                    domain["elb"]["name"], int(domain["elb"].get("port", 443))
+                )
+            else:
+                raise ValueError(
+                    "Unknown certificate location: {!r}".format(domain)
+                )
 
-    if persistent:
-        logger.emit("running", mode="persistent")
-        while True:
-            update_certs(
-                logger, acme_client,
-                force_issue, certificate_requests
-            )
-            # Sleep before we check again
-            logger.emit("sleeping", duration=PERSISTENT_SLEEP_INTERVAL)
-            time.sleep(PERSISTENT_SLEEP_INTERVAL)
-    else:
-        logger.emit("running", mode="single")
+            certificate_requests.append(CertificateRequest(
+                cert_location,
+                Route53ChallengeCompleter(route53_client),
+                domain["hosts"],
+                domain.get("key_type", "rsa"),
+            ))
+
         update_certs(
             logger, acme_client,
             force_issue, certificate_requests
         )
+
+        if persistent:
+            # Sleep before we check again
+            logger.emit("sleeping", duration=PERSISTENT_SLEEP_INTERVAL)
+            time.sleep(PERSISTENT_SLEEP_INTERVAL)
+            config.read()
+        else:
+            break
 
 
 @cli.command()
@@ -552,7 +599,7 @@ def update_certificates(persistent=False, force_issue=False):
 )
 def register(email, out):
     logger = Logger()
-    config = json.loads(os.environ.get("LETSENCRYPT_AWS_CONFIG", "{}"))
+    config = Config(logger, default={})
     acme_directory_url = config.get(
         "acme_directory_url", DEFAULT_ACME_DIRECTORY_URL
     )


### PR DESCRIPTION
Systems like kubernetes allow you to specify configuration via a
configmap/secret which can be updated and will update the file within
the container.  Environment variables do not have this feature.  When it
comes to managing this inside a container in a kubernetes cluster, this
will allow you to update the configuration without restarting the
container.

Current configurations will not be broken as the environment variable is
still in use and preferred.  To use this feature, you must only set the
LETSENCRYPT_AWS_CONFIG_FILE environment variable but will default to
config.json in the directory its run from.
